### PR TITLE
Added unit stance, role, gender, race and obtain properties to footer on getThumbnailEmbed

### DIFF
--- a/commands/worldFlipper.js
+++ b/commands/worldFlipper.js
@@ -103,7 +103,7 @@ const getThumbnailEmbed = (unit, flag) => {
   if (unit.Obtain) {
     footer = footer + ' - ' + unit.Obtain;
   }
-  footer += '           ' + devNicknames + '       JP' + (unit.InGlobal?' GL':'') + (unit.InTaiwan?' TW':'')
+  footer += '           ' + devNicknames + (unit.InTaiwan?' TW':'')
   var msg = new Discord.MessageEmbed()
     .setTitle(unit.ENName + ' ' + unit.JPName)
     .setDescription((unit.AlsoKnownAs?'**Also Known As: **'+unit.AlsoKnownAs+'\n':'')+'**Attribute: **' + unit.Attribute


### PR DESCRIPTION
Added the unit stance, role, gender, race and obtain properties to thumbnail embed so information is easily available in situations where the user doesn't care about the skill/ability info. Another use case would be when the user just want's to know one of those pieces of information but doesn't want to flood chat with big embed.